### PR TITLE
Remove sentence discouraging => with void (#1187)

### DIFF
--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -903,10 +903,6 @@ num get x => center.x;
 set x(num value) => center = Point(value, center.y);
 {% endprettify %}
 
-It's rarely a good idea to use `=>` for non-setter void members. The `=>`
-implies "returns a value", so readers may misinterpret what the void member does
-if you use it.
-
 
 ### DON'T use `this.` when not needed to avoid shadowing.
 


### PR DESCRIPTION
In practice we see a lot of usage of `=>` with a void return. The
practice is more closely aligned with using arrow functions for nearly
any single expression method, regardless of whether it returns a value.

We don't need to explicitly encourage using arrow functions this way,
but we also want to allow it for the authors who are already doing it.